### PR TITLE
El mapa ahora recoge datos reales

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -7,5 +7,13 @@
     },
     "useSocketIo": false,
     "noCache": false
+  },
+  "mapConfig": {
+    "center": {
+      "latitude": 41.4,
+      "longitude": 2.16
+    },
+    "zoom": 14,
+    "happinessesQueryLimit": 20
   }
 }

--- a/config/production.json
+++ b/config/production.json
@@ -7,5 +7,13 @@
     },
     "useSocketIo": false,
     "noCache": false
+  },
+  "mapConfig": {
+    "center": {
+      "latitude": 41.4,
+      "longitude": 2.16
+    },
+    "zoom": 14,
+    "happinessesQueryLimit": 20
   }
 }

--- a/www/js/directives.js
+++ b/www/js/directives.js
@@ -1,5 +1,5 @@
 angular.module('app.directives', ['app.services'])
-.directive('hackhappinesAddhackhappines', function(Happinesses, GeoService) {
+.directive('hackhappinesAddhackhappines', function(HappinessesService, GeoService) {
   return {
     restrict: 'E',
     replace: true,
@@ -9,7 +9,7 @@ angular.module('app.directives', ['app.services'])
       {
           // Perform the action when the user submits the login form
           $scope.addHappiness = function() {
-            Happinesses.post($scope.happinessData)
+            HappinessesService.post($scope.happinessData)
               .success($scope.closeAddHappiness);
           };
           
@@ -37,17 +37,14 @@ angular.module('app.directives', ['app.services'])
           {
             if( lat === null && lng === null )
             {
-              $scope.happinessData.latlng = null;
+              $scope.happinessData.loc = null;
               $scope.happinessData.city = null;
               $scope.happinessData.country = null;
 
             }
             else
             {
-              $scope.happinessData.latlng = {
-                lat: lat,
-                lng: lng
-              };
+              $scope.happinessData.loc = [lng, lat];
               var latLng = new google.maps.LatLng(lat, lng);
               GeoService.geocoder.geocode({latLng: latLng}, function(response, status) {
                 if (status == google.maps.GeocoderStatus.OK)
@@ -82,7 +79,7 @@ angular.module('app.directives', ['app.services'])
             $scope.happinessData = {
               level: 0,
               message: '',
-              latlng: {}
+              loc: []
             };
             $scope.allowGeolocale = false;
             $scope.geolocating = false;


### PR DESCRIPTION
Se modificó la estructura de la localización geográfica. Ahora es un
array de la forma [longitud, latitud]. Este es el formato que acepta
MongoDB para los geo.

Se agregó un método de query .allByBox que recibe las coordenadas de
los puntos suroeste y noreste del mapa visualizado y devuelve los
happinesses comprendidos dentro de ese rectángulo imaginario. Se ha
limitado la query a 20 happinesses (definido en constants.js)

De momento no se ha agregado ningún indice. Estimo que se verá al
momento de necesitarlo.
